### PR TITLE
Enhance Deployment API to Include Location, Device, and User Information

### DIFF
--- a/ingester/database.py
+++ b/ingester/database.py
@@ -698,8 +698,12 @@ class GraphDB:
             OPTIONAL MATCH (d)-[:DEPLOYED_IN]->(e:EdgeDevice)
             OPTIONAL MATCH (d)<-[:DEPLOYMENT_INFO]-(exp:Experiment)-[:SUBMITTED_BY]->(u:User)
             RETURN properties(d) AS deployment_info,
-                   e.location AS location,
-                   e.device_type AS device,
+                   {
+                       device_id: e.device_id,
+                       device_type: e.device_type,
+                       location: e.location,
+                       name: e.name
+                   } AS device_info,
                    u.user_id AS user
         """
         with self.driver.session() as session:
@@ -707,8 +711,7 @@ class GraphDB:
             records = []
             for record in result:
                 deployment = record["deployment_info"]
-                deployment["location"] = record.get("location")
-                deployment["device"] = record.get("device")
+                deployment["device"] = record.get("device_info")
                 deployment["user"] = record.get("user")
                 records.append(deployment)
             return records

--- a/ingester/database.py
+++ b/ingester/database.py
@@ -695,11 +695,22 @@ class GraphDB:
     def get_deployments(self, model_id):
         query = """
             MATCH (m:Model {model_id: $model_id})-[:HAS_DEPLOYMENT]->(d:Deployment)
-            RETURN properties(d) as deployment_info
+            OPTIONAL MATCH (d)-[:DEPLOYED_IN]->(e:EdgeDevice)
+            OPTIONAL MATCH (d)<-[:DEPLOYMENT_INFO]-(exp:Experiment)-[:SUBMITTED_BY]->(u:User)
+            RETURN properties(d) AS deployment_info,
+                   e.location AS location,
+                   e.device_type AS device,
+                   u.user_id AS user
         """
         with self.driver.session() as session:
             result = session.run(query, model_id=model_id)
-            records = [record["deployment_info"] for record in result]
+            records = []
+            for record in result:
+                deployment = record["deployment_info"]
+                deployment["location"] = record.get("location")
+                deployment["device"] = record.get("device")
+                deployment["user"] = record.get("user")
+                records.append(deployment)
             return records
 
     def set_model_location(self, model_id, location):

--- a/server/server.py
+++ b/server/server.py
@@ -142,7 +142,7 @@ class DeploymentInfo(Resource):
         if deployments is None:
             return {"error": "Deployments not found!"}, 400
 
-        return deployments, 200
+        return jsonify(deployments), 200
 
 # Update model location
 @api.route('/update_model_location')


### PR DESCRIPTION
This pull request updates the /model_deployments API endpoint to return additional metadata (location, device, and user) for deployments associated with a given model_id. The changes traverse the graph to fetch data from related EdgeDevice and User nodes.


Expected Response:
[
    {
        "deployment_id": "megadetector-iu-animal-test",
        "start_time": 1726600436504,
        "end_time": 1726600513481,
        "total_cpu_power_consumption": 67.42259844772727,
        "total_gpu_power_consumption": 0.0,
        "image_generating_plugin_gpu_power_consumption": 0,
        "image_scoring_plugin_gpu_power_consumption": 0.0,
        "power_monitor_plugin_cpu_power_consumption": 5.644445,
        "image_scoring_plugin_cpu_power_consumption": 56.26406144772727,
        "image_generating_plugin_cpu_power_consumption": 5.514092,
        "power_monitor_plugin_gpu_power_consumption": 0,
        "location": "okavango-delta",
        "device": "jetson-nano",
        "user": "jstubbs"
    }
]