### PR TITLE
Integrate TAPIS Authentication

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -2,7 +2,7 @@ import os
 import logging
 from urllib.parse import urlparse
 
-from flask import Flask, request, jsonify, Response, make_response
+from flask import Flask, request, jsonify, Response
 from flask_restx import Api, Resource
 
 from ingester.neo4j_ingester import MCIngester
@@ -130,11 +130,7 @@ class ListModels(Resource):
         Lists all the models in Patra KG.
         """
         model_card_dict = mc_reconstructor.get_all_mcs()
-
-        response = make_response(model_card_dict, 200)
-        response.headers["username"] = request.headers.get("Tapis-Trusted-Username-Header", None)
-
-        return response
+        return model_card_dict, 200
 
 
 @api.route('/model_deployments')
@@ -224,11 +220,7 @@ class HFcredentials(Resource):
         hf_token = os.getenv("HF_HUB_TOKEN")
         if not hf_username or not hf_token:
             return {"error": "Hugging Face credentials not set."}, 400
-
-        response = make_response({"username": hf_username, "token": hf_token}, 200)
-        response.headers["username"] = request.headers.get("Tapis-Trusted-Username-Header", None)
-
-        return response
+        return {"username": hf_username, "token": hf_token}, 200
 
 
 @api.route('/get_github_credentials')
@@ -260,8 +252,8 @@ class ModelCardLinkset(Resource):
         model_card = mc_reconstructor.reconstruct(str(mc_id))
 
         if not model_card:
-            error_payload = jsonify({"error": f"Model card with ID '{mc_id}' could not be found!"})
-            return Response(response=error_payload.get_data(as_text=True), status=404, mimetype='application/json')
+             error_payload = jsonify({"error": f"Model card with ID '{mc_id}' could not be found!"})
+             return Response(response=error_payload.get_data(as_text=True), status=404, mimetype='application/json')
 
         generated_headers = mc_reconstructor.get_link_headers(model_card)
 

--- a/server/server.py
+++ b/server/server.py
@@ -132,7 +132,7 @@ class ListModels(Resource):
         model_card_dict = mc_reconstructor.get_all_mcs()
         response = make_response(model_card_dict, 200)
 
-        trusted_username = request.headers.get("tapis_validated_username", None)
+        trusted_username = dict(request.headers).get("tapis_validated_username", None)
         response.headers["tapis_validated_username"] = trusted_username
 
         return response

--- a/server/server.py
+++ b/server/server.py
@@ -213,26 +213,6 @@ class GeneratePID(Resource):
         return {"pid": pid}, 201
 
 
-@app.route('/verify_token', methods=['GET'])
-def verify_token():
-    # Extract and validate the access token from the Authorization header.
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        return jsonify({"error": "Access token required."}), 401
-
-    token = auth_header.split(" ")[1]
-
-    # Attempt to decode the token; return error if any exception occurs.
-    try:
-        decoded = jwt.decode(token, PUBLIC_KEY, algorithms=["RS256"])
-    except Exception as e:
-        app.logger.error(f"Token verification error: {e}")
-        return jsonify({"error": "Invalid or expired access token."}), 401
-
-    # Token is valid; return decoded claims for debugging.
-    return jsonify({"message": "User verified successfully.", "claims": decoded}), 200
-
-
 @api.route('/get_huggingface_credentials')
 class HFcredentials(Resource):
     def get(self):

--- a/server/server.py
+++ b/server/server.py
@@ -183,7 +183,6 @@ class UpdateModelLocation(Resource):
 @api.route('/get_model_id')
 class GeneratePID(Resource):
     @api.param('name', 'Model name')
-    @api.param('author', 'Model author')
     @api.param('version', 'Model version')
     def get(self):
         """

--- a/server/server.py
+++ b/server/server.py
@@ -179,6 +179,7 @@ class UpdateModelLocation(Resource):
 @api.route('/get_model_id')
 class GeneratePID(Resource):
     @api.param('name', 'Model name')
+    @api.param('author', 'Model author')
     @api.param('version', 'Model version')
     def get(self):
         """
@@ -189,6 +190,8 @@ class GeneratePID(Resource):
             400: Missing parameters
         """
         author = request.headers.get("Tapis-Trusted-Username-Header", None)
+        if author is None:
+            author = request.args.get('author')
         name = request.args.get('name')
         version = request.args.get('version')
 

--- a/server/server.py
+++ b/server/server.py
@@ -132,8 +132,8 @@ class ListModels(Resource):
         model_card_dict = mc_reconstructor.get_all_mcs()
         response = make_response(model_card_dict, 200)
 
-        trusted_username = request.headers.get("TAPIS_TRUSTED_USERNAME_HEADER", None)
-        response.headers["TAPIS_TRUSTED_USERNAME_HEADER"] = trusted_username
+        trusted_username = request.headers.get("tapis_validated_username", None)
+        response.headers["tapis_validated_username"] = trusted_username
 
         return response
 

--- a/server/server.py
+++ b/server/server.py
@@ -130,10 +130,9 @@ class ListModels(Resource):
         Lists all the models in Patra KG.
         """
         model_card_dict = mc_reconstructor.get_all_mcs()
-        response = make_response(model_card_dict, 200)
 
-        trusted_username = dict(request.headers).get("tapis_validated_username", None)
-        response.headers["tapis_validated_username"] = trusted_username
+        response = make_response(model_card_dict, 200)
+        response.headers["username"] = request.headers.get("Tapis-Trusted-Username-Header", None)
 
         return response
 
@@ -194,7 +193,7 @@ class GeneratePID(Resource):
             409: PID already exists; user must update version
             400: Missing parameters
         """
-        author = request.args.get('author')
+        author = request.headers.get("Tapis-Trusted-Username-Header", None)
         name = request.args.get('name')
         version = request.args.get('version')
 
@@ -226,7 +225,11 @@ class HFcredentials(Resource):
         hf_token = os.getenv("HF_HUB_TOKEN")
         if not hf_username or not hf_token:
             return {"error": "Hugging Face credentials not set."}, 400
-        return {"username": hf_username, "token": hf_token}, 200
+
+        response = make_response({"username": hf_username, "token": hf_token}, 200)
+        response.headers["username"] = request.headers.get("Tapis-Trusted-Username-Header", None)
+
+        return response
 
 
 @api.route('/get_github_credentials')


### PR DESCRIPTION
Updated the retrieval of the `author` parameter in the `get` method to use the `Tapis-Trusted-Username-Header` from request headers instead of query parameters. 